### PR TITLE
Update synchronous code

### DIFF
--- a/src/redux/actions/connection-actions.js
+++ b/src/redux/actions/connection-actions.js
@@ -72,7 +72,6 @@ export function watchNetworkStatus() {
     const latestStatus = web3.eth.filter('latest')
 
     latestStatus.watch((err, blockHash) => {
-
       return new Promise((resolve, reject) => {
         web3.eth.getBlock(blockHash, false, function(err, block) {
           if (err) reject(err)

--- a/src/redux/actions/connection-actions.js
+++ b/src/redux/actions/connection-actions.js
@@ -7,7 +7,7 @@ else if (typeof Web3 !== 'undefined') {
   web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'))
   if (!web3.isConnected()) {
     const Web3 = require('web3')
-    web3 = new Web3(new Web3.providers.HttpProvider('https://signal.ether.ai/proxy'))
+    web3 = new Web3(new Web3.providers.HttpProvider('http://rpc.ethapi.org:8545'))
   }
 }
 

--- a/src/redux/actions/position-actions.js
+++ b/src/redux/actions/position-actions.js
@@ -1,5 +1,3 @@
-const API_KEY = process.env.ETHERSCAN_API_KEY
-
 import querystring from 'querystring'
 import fetch from 'isomorphic-fetch'
 import getSignalPerBlock from './utils/getSignalPerBlock'
@@ -20,7 +18,7 @@ else if (typeof Web3 !== 'undefined') {
   web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'))
   if (!web3.isConnected()) {
     const Web3 = require('web3')
-    web3 = new Web3(new Web3.providers.HttpProvider('https://signal.ether.ai/proxy'))
+    web3 = new Web3(new Web3.providers.HttpProvider('http://rpc.ethapi.org:8545'))
   }
 }
 

--- a/src/redux/actions/position-actions.js
+++ b/src/redux/actions/position-actions.js
@@ -397,13 +397,20 @@ export function submitNewPosition(title, description, account) {
   return dispatch => {
     dispatch(submitNewPositionRequest())
     try {
-      const result = positionRegistry.registerPosition.sendTransaction(
-        title,
-        description,
-        { from: sender, to: address, gas: gas }
+      positionRegistry.registerPosition.sendTransaction(
+        {
+          title,
+          description,
+          from: sender,
+          to: address,
+          gas: gas
+        },
+        (err, result) => {
+          if (err) throw err
+          dispatch(addTimedAlert('The position was submitted!', 'success'))
+          dispatch(submitNewPositionSuccess(result))
+        }
       )
-      dispatch(addTimedAlert('The position was submitted!', 'success'))
-      dispatch(submitNewPositionSuccess(result))
     }
     catch (error) {
       dispatch(addTimedAlert(error.message, 'danger'))

--- a/src/redux/actions/position-actions.js
+++ b/src/redux/actions/position-actions.js
@@ -94,12 +94,12 @@ function getPositions(fromBlock, endBlock) {
 
 function getPositionDeposit(position) {
   return new Promise((resolve, reject) => {
-    const block = web3.eth.getBlock(position.blockNumber)
-    const deposit = Number(web3.fromWei(
-      web3.eth.getBalance(position.args.sigAddr),
-      'finney'
-    ))
-    resolve(Object.assign({}, position, {block, deposit}))
+    web3.eth.getBlock(position.blockNumber, (err, block) => {
+      web3.eth.getBalance(position.args.sigAddr, (err, balance) => {
+        const deposit = Number(web3.fromWei(balance, 'finney'))
+        resolve(Object.assign({}, position, {block, deposit}))
+      })
+    })
   })
 }
 
@@ -170,6 +170,7 @@ function calculateCurrentSignal(position) {
     for (const address in position.proMap) {
 
       const balance = web3.fromWei(web3.eth.getBalance(address))
+
       position.proMap[address] = position.proMap[address] * balance
       position.againstMap[address] = position.againstMap[address] * balance
 
@@ -187,6 +188,7 @@ function calculateCurrentSignal(position) {
           }
         }
       })
+
     }
 
     for (const index in web3.eth.accounts) {

--- a/src/redux/actions/position-actions.js
+++ b/src/redux/actions/position-actions.js
@@ -392,30 +392,34 @@ export function submitNewPosition(title, description, account) {
   // Todo: there should be an account selector
   const sender = account
   const data = positionRegistry.registerPosition.getData(title, description)
-  const gas = web3.eth.estimateGas({from: sender, to: address, data: data})
 
   return dispatch => {
     dispatch(submitNewPositionRequest())
-    try {
-      positionRegistry.registerPosition.sendTransaction(
-        {
+    web3.eth.estimateGas({from: sender, to: address, data: data}, (err, gas) => {
+      try {
+        positionRegistry.registerPosition.sendTransaction(
           title,
           description,
-          from: sender,
-          to: address,
-          gas: gas
-        },
-        (err, result) => {
-          if (err) throw err
-          dispatch(addTimedAlert('The position was submitted!', 'success'))
-          dispatch(submitNewPositionSuccess(result))
-        }
-      )
-    }
-    catch (error) {
-      dispatch(addTimedAlert(error.message, 'danger'))
-      dispatch(submitNewPositionFailure(error))
-    }
+          {
+            from: sender,
+            to: address,
+            gas: gas
+          },
+          (err, result) => {
+            if (err) throw err
+            dispatch(addTimedAlert('The position was submitted!', 'success'))
+            dispatch(submitNewPositionSuccess(result))
+          }
+        )
+      }
+
+      catch (error) {
+        dispatch(addTimedAlert(error.message, 'danger'))
+        dispatch(submitNewPositionFailure(error))
+      }
+
+    })
+
   }
 
 }


### PR DESCRIPTION
Includes code from PR#40 
- Replaces several synchronous calls to web3.js with their async versions.  
- Site runs in Mist and Chrome w/ Metamask. 
- Haven't been able to test submission of new positions or up or down voting on positions in Chrome yet, because a pending transfer of TestNet eth has yet to complete.
